### PR TITLE
Update to config schema to fix the plugin settings 

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,10 +8,25 @@
 
 # Homebridge Sky Q Tv Accessory
 
-The first TV Accessory for SKY Q, ability to use control centre remote for sky box
+The first TV Accessory for SKY Q, ability to use control centre remote for a Sky Q box and adds it to the Home app as a Set Top Box
 
-Setup Example Config:
+## Installation
 
+Option 1: Install the plugin via [config-ui-x](https://github.com/oznu/homebridge-config-ui-x):
+- Search for Sky Q TV Remote on config-ui-x plugin screen
+- Click Install on homebridge Dyson Pure Cool plugin
+- Once installed you will be prompted to set the config
+- Restart homebridge service and plugin should be loaded with accessories
+
+Option 2: Install the plugin via npm:
+
+```bash
+npm install homebridge-skyq-tvremote -g
+```
+
+## Configuration
+
+```json
 "platforms": [
         {
             "name": "Sky Q TV",
@@ -19,3 +34,49 @@ Setup Example Config:
             "ipaddress": "192.xxx.x.x"
         }
     ]
+```
+### Multiple boxes
+
+If you have multiple Sky Q boxes then the config could look something like this:
+
+```json
+"platforms": [
+        {
+            "name": "Sky Q TV",
+            "platform": "skyq-tvremote",
+            "ipaddress": "192.xxx.x.1"
+        },
+        {
+            "name": "Sky Q Mini",
+            "platform": "skyq-tvremote",
+            "ipaddress": "192.xxx.x.2"
+        },
+        {
+            "name": "Sky Q Mini 2",
+            "platform": "skyq-tvremote",
+            "ipaddress": "192.xxx.x.3"
+        }
+        ]
+```        
+
+**name**: The Name of your Sky Q box in the Home app
+
+**ipaddress**: Local IP address of the device.
+
+## Add Sky Q box to the Home app
+
+There is a homekit limitation that allows only one TV per bridge. Therefore each Sky Q box will be exposed as external accessory and will not show up when only the homebridge-bridge was added. To add each of your Sky Q boxes
+
+1. Open the Home App
+2. Type `+` in the top right corner to add a device
+3. Then click on **Don't Have a Code or Can't scan?**
+4. The found TV should appear under **Nearby Accessories** ... click on it
+5. Use the PIN that is set in **config.json** under `config > bridge > pin`
+
+## Getting the Sky Q Box IP address
+
+On your Sky Q Box, go to:
+
+Settings -> Setup -> Network -> Advanced Settings -> IP address
+
+If you dont reserve an IP address on your router via the DHCP settings then it may get a differnt IP if you restart your router and this will cause the plugin to fail.

--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 
 
 # Homebridge Sky Q Tv Accessory
-
-The first TV Accessory for SKY Q, ability to use control centre remote for a Sky Q box and adds it to the Home app as a Set Top Box
+Accessory for SKY Q which adds it to the Home app as a Set-Top Box with the ability to use the Control Centre remote functionality.
 
 ## Installation
 
@@ -35,6 +34,12 @@ npm install homebridge-skyq-tvremote -g
         }
     ]
 ```
+**name**: The Name of your Sky Q box in the Home app
+
+**ipaddress**: Local IP address of the device
+
+#### Note: If you rename one of the boxes via the UI or in the config it will need to be removed and added back into the Home app
+
 ### Multiple boxes
 
 If you have multiple Sky Q boxes then the config could look something like this:
@@ -59,19 +64,15 @@ If you have multiple Sky Q boxes then the config could look something like this:
         ]
 ```        
 
-**name**: The Name of your Sky Q box in the Home app
-
-**ipaddress**: Local IP address of the device.
-
 ## Add Sky Q box to the Home app
 
-There is a homekit limitation that allows only one TV per bridge. Therefore each Sky Q box will be exposed as external accessory and will not show up when only the homebridge-bridge was added. To add each of your Sky Q boxes
+There is a homekit limitation that allows only one Set-Top box per bridge. Therefore each Sky Q box will be exposed as external accessory and will not show up when only the homebridge-bridge was added. To add each Sky Q box:
 
 1. Open the Home App
-2. Type `+` in the top right corner to add a device
-3. Then click on **Don't Have a Code or Can't scan?**
-4. The found TV should appear under **Nearby Accessories** ... click on it
-5. Use the PIN that is set in **config.json** under `config > bridge > pin`
+1. Type `+` in the top right corner to add a device
+1. Then click on **Don't Have a Code or Can't scan?**
+1. The found TV should appear under **Nearby Accessories** ... click on it
+1. Use the PIN that is set in **config.json** under `config > bridge > pin`
 
 ## Getting the Sky Q Box IP address
 

--- a/config.schema.json
+++ b/config.schema.json
@@ -1,7 +1,8 @@
 {
   "pluginAlias": "skyq-tvremote",
   "pluginType": "platform",
-  "singular": true,
+  "footerDisplay": "For help please see the [README on GitHub ](https://github.com/neilpatel121/homebridge-skyq-tvremote).",
+  "singular": false,
   "schema": {
     "type": "object",
     "properties": {
@@ -9,7 +10,16 @@
         "title": "Name",
         "type": "string",
         "required": true,
-        "default": "Sky Q TV"
+        "placeholder": "Sky Q TV",
+        "description": "Name of the Set Top Box"
+      },
+      "ipaddress": {
+        "title": "IP Address",
+        "type": "string",
+        "required": true,
+        "placeholder": "192.168.0.0",
+        "format": "ipv4",
+        "description": "The IPv4 address of your Sky Q Box"
       }
     }
   }


### PR DESCRIPTION
I noticed that if you changed the name in the plugin settings UI it removed the IP address and also only allowed one box to be changed so this fixes that. Changes tested locally on my instance.

I have also updated the readme to include this info and also show how to add multiple boxes as raised in https://github.com/neilpatel121/homebridge-skyq-tvremote/issues/5