### PR TITLE
Fix empty favourite

### DIFF
--- a/src/platform.ts
+++ b/src/platform.ts
@@ -149,7 +149,7 @@ export class SkyTVPlugin implements IndependentPlatformPlugin {
             favoritesData.favourites.forEach(favorite => {
               const service = servicesData.services.filter(service => service.sid === favorite.sid)[0];
 
-              if (!service.t || !service.c) {
+              if (!service || !service.t || !service.c) {
                 return;
               }
     


### PR DESCRIPTION
### Bug Fixes

* Fixes #27 - Fixed an issue to handle the situation where Sky Q has gaps in the favourites. This should fix the situations where inputs had no associated service.